### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = @item.user
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -39,4 +39,9 @@ class Item < ApplicationRecord
 
   # userが紐ついていないと保存できなようにする
   validates :user, presence: true
+
+  def owned_by?(user)
+    # ログインしていない場合を考慮し、userが存在するかを先に確認
+    user.present? && user_id == user.id
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
     <% if @items.present? %>
        <% @items.each do |item| %>
         <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,38 +4,47 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
+
+  
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# if item.order.present? %>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
+      <%# end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+         <%= number_to_currency(@item.price, unit: "¥", format: "%u%n") %>
       </span>
       <span class="item-postage">
         <%= "配送料負担" %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
+    <%# <% if @item.order.blank? %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%# link_to "購入画面に進む", "#" ,class:"item-red-btn"%>  
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+  
 
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%if user_signed_in? && current_user.id == @item.user_id %>
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %> 
+     <p class="or-text">or</p> 
+    <%=link_to "削除", "#",data: {turbo_method: :delete}, class:"item-destroy" %> 
+    <% elsif user_signed_in? %> 
+    <%# 状況C: ログインしているが、出品者ではない場合 %>
+    <%= link_to '購入画面に進む',item_orders_path(@item),class: "item-red-btn" %> 
+    <% end %> 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# <% end %> 
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -44,27 +53,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_payer.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,44 +10,36 @@
   
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# if item.order.present? %>
-      <%# <div class="sold-out"> %>
-        <%# <span>Sold Out!!</span> %>
-      <%# </div> %>
-      <%# end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+        <%# if item.order.present? %>
+         <%# <div class="sold-out"> %>
+         <%# <span>Sold Out!!</span> %>
+    <%# </div> %>
+        <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
          <%= number_to_currency(@item.price, unit: "¥", format: "%u%n") %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_payer.name %>
       </span>
     </div>
 
-    <%# <% if @item.order.blank? %> 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%# link_to "購入画面に進む", "#" ,class:"item-red-btn"%>  
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-  
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <%if user_signed_in? && current_user.id == @item.user_id %>
+    <% if @item.owned_by?(current_user) %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %> 
      <p class="or-text">or</p> 
     <%=link_to "削除", "#",data: {turbo_method: :delete}, class:"item-destroy" %> 
+
     <% elsif user_signed_in? %> 
     <%# 状況C: ログインしているが、出品者ではない場合 %>
-    <%= link_to '購入画面に進む',item_orders_path(@item),class: "item-red-btn" %> 
+    <%= link_to '購入画面に進む',"#",class: "item-red-btn" %> 
     <% end %> 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <%# <% end %> 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -112,9 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root to: 'items#index'
-  resources :items
+  resources :items do
+    resources :orders
+  end
 
 end


### PR DESCRIPTION
# Wht
- 商品詳細表示機能の実装

# Why
- 商品の詳細ページに商品に関する詳細情報を表示させるため
- ログインとログアウトで異なるボタンの表示、自身が自身で出品した商品を購入できない、他の方が出品した商品のみ購入
- 自身のページには、編集、削除ボタンを表示、購入ボタンはなし

#動画
- ログイン状態且つ、自身が出品登録した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/1e9f62739ad30793c71b2d07f9d8612c

 - ログイン状態且つ、別のアカウントで出品登録の販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/c5f5955c973ac6bc9fe40e156d7fb7e9

  - ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/1f2589af029303d6bb8bc1515dddb3a5

**※商品購入機能は、未実装**

ご確認のほど、どうぞよろしくお願いいたします。